### PR TITLE
chore: fix params for ffpmeg and MediaRecorder

### DIFF
--- a/src/chrome-extension/options.ts
+++ b/src/chrome-extension/options.ts
@@ -36,7 +36,7 @@ async function startStreaming(port: number) {
   await new Promise((resolve) => setTimeout(resolve, 2000));
 
   const recorder = new MediaRecorder(stream, {
-    audioBitsPerSecond: 160000,
+    audioBitsPerSecond: 192000,
     videoBitsPerSecond: 8000000,
   });
   recorder.start(1500);

--- a/src/ffmpeg.ts
+++ b/src/ffmpeg.ts
@@ -54,10 +54,6 @@ export function streamToRtmp(stream: Stream, rtmp: string) {
     '-r',
     '30',
     // frame rate 25
-    // video size
-    '-s',
-    '1920x1080',
-    // video size
     // set GOP (should be half of fps)
     '-g',
     '60',
@@ -78,22 +74,8 @@ export function streamToRtmp(stream: Stream, rtmp: string) {
     '3.1',
     '-c:a',
     'aac',
-    // audio bitrate
-    '-b:a',
-    '44k',
-    // audio bitrate
-    // audio stereo
     '-ac',
     '2',
-    // audio stereo
-    // bitrate
-    '-b:v',
-    '8000K',
-    '-maxrate',
-    '9000K',
-    '-bufsize',
-    '4000K',
-    // bitrate
     '-ar',
     String(128000 / 4),
     '-f',


### PR DESCRIPTION
- remove ffpmeg params for video/audio size/bitrate
- use 192kbps for audio in MediaRecorder